### PR TITLE
.github: bump go version to 1.16.x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16.x
       - run: go test -race -v ./...
   lint:
     name: Lint


### PR DESCRIPTION
Since when go1.17 will be released next Monday, thus it's EOL for go1.15