### PR TITLE
.github: improve ci run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,17 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: 1.16.x
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/go/bin
+            ~/go/src
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       - run: go test -race -v ./...
   lint:
     name: Lint
@@ -21,5 +32,3 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: golangci/golangci-lint-action@v2
-        with:
-          version: v1.32


### PR DESCRIPTION
 - Adding cache for go module
 - Always use latest version of golangci-lint