### PR TITLE
.github: add workflow to auto-release a docker image on ghcr

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,0 +1,16 @@
+name: Build Docker image
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .

--- a/.github/workflows/deploy-image.yaml
+++ b/.github/workflows/deploy-image.yaml
@@ -1,0 +1,41 @@
+name: Create and publish a Docker image
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM golang:latest
+FROM golang as builder
 
 # Add Code and install
 ADD . /go/src/github.com/orijtech/tickeryzer/
 WORKDIR /go/src/github.com/orijtech/tickeryzer/cmd/tickeryzer
 RUN go install -v
 
+FROM alpine:latest
+COPY --from=builder /go/bin/tickeryzer /go/bin/tickeryzer
 # Setup work path
 WORKDIR /data
 ENTRYPOINT ["/go/bin/tickeryzer"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang as builder
+FROM golang:latest as builder
 
 # Add Code and install
 ADD . /go/src/github.com/orijtech/tickeryzer/


### PR DESCRIPTION
I also added a workflow to build the image on PRs and updated the Dockerfile to copy the tickeryzer binary to an alpine image. This takes our image size down from ~1GB to 13.2MB :)

Updates #11