### PR TITLE
Dockerfile: use golang alpine for all build stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:latest as builder
+FROM golang:alpine as builder
 
 # Add Code and install
 ADD . /go/src/github.com/orijtech/tickeryzer/
 WORKDIR /go/src/github.com/orijtech/tickeryzer/cmd/tickeryzer
 RUN go install -v
 
-FROM alpine:latest
+FROM golang:alpine
 COPY --from=builder /go/bin/tickeryzer /go/bin/tickeryzer
 # Setup work path
 WORKDIR /data


### PR DESCRIPTION
Unfortunately, golang:alpine is much bigger than alpine (328MB vs 5.59MB) but tickeryzer needs go installed to work: https://cs.opensource.google/go/x/tools/+/master:internal/gocommand/invoke.go;l=159;drc=897bd77cd7177f6d679eafa9767ff6ef9211458a

Updates #11